### PR TITLE
 Merge recent Flathub Bot merge in 23.08 branch into 22.08 branch

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -16,6 +16,7 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
+    <release version="jdk-21.0.2+13" date="2024-02-22"/>
     <release version="jdk-21.0.1+12" date="2023-10-27"/>
     <release version="jdk-21.0.0+35" date="2023-10-11"/>
   </releases>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -24,29 +24,29 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 496ed15dcba607cd1b9e6786932429f9d213d2ea22203bf8cbed61880655ee046bfc4c07b7b0d54285081ddf242fd8957ba34c8be75f5fb2ae0aac16f9b8ef3a
+        sha512: 691ec4d447933c59696944cdb5d5de86fc1332b2c730dc6624f546c0d30456cb3583d53f38d7531f69195e807092c1d03d923d73d5e6883185cae935db1ed7ce
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
           versions:
-            -  "==": 21
+            - ==: 21
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.2_13.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: ed05b9733e8270fe73dab86fb9320689a6613dd2d6a5807a47a2e22f081feefd9729e39521c85f3f443687bd103918850a9bd3a27d1a64b8519bb37c7454e5e8
+        sha512: a41a31915ea64cbdae4e9b81057df579d8456a5ca5e224497e862dbb207275f9d84dd91d9c9cce4d81b03d21d3d4305e3276d064ec1e32b6d1f272f157c82f56
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=aarch64&image_type=jdk
           version-query: .[0].version.semver
           url-query: .[0].binary.package.link
           versions:
-            -  "==": 21
+            - ==: 21
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.bz2 --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
@@ -87,8 +87,8 @@ modules:
       - (cd $FLATPAK_DEST/jvm && ln -s openjdk-21.* openjdk-21)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.1+12.tar.gz
-        sha512: a21f39ad489455a25093a7d6e216418efa991aa92dbd631d3dfcb2847ec7f5ca85277cb7a192f44549687fe5323236404c80e4b3e4fe54b7b03230c2fa38e07a
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.2+13.tar.gz
+        sha512: aa087ec261e67a53f7589882481c8c08717d22a7a345091d2368b0a823fcfd5688246b07f17c3d66c6693601dd6749e5689922e9569c481ca0086557dcae2f1d
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -96,7 +96,7 @@ modules:
           url-query: '"https://github.com/openjdk/jdk21u/archive/refs/tags/" + $version
             + ".tar.gz"'
           versions:
-            -  "==": 21
+            - ==: 21
           is-main-source: true
       - type: patch
         path: 0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
@@ -156,9 +156,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.5-bin.zip
+        url: https://services.gradle.org/distributions/gradle-7.6.4-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: c0c07fcee0802cbdf8156475280f961ef9c0d928252642363314e25da69803fd878ab65bdc1647efa5f4b1e9b7f71e6a4daa6946d9f9923628248e9f35e8b14b
+        sha512: 65c9bdb55d53349f3bc04d84b658589f6ab889e58280ecdc3714634c3f94aabf5354e7b52474008d2aa642eb42b3aa55cf569b11a8659c69341d2d1b9e97f1eb
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases
@@ -201,4 +201,5 @@ modules:
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/share/metainfo
       - cp org.freedesktop.Sdk.Extension.openjdk21.appdata.xml ${FLATPAK_DEST}/share/metainfo
-      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak
+        ${FLATPAK_ID}


### PR DESCRIPTION
Because the 22.08 FreeDesktop runtime is not yet EOL.

Done in a different way from #40, presumably due to (as of the time of posting this comment) ongoing Buildbot pipelines for the 23.08 branch that have not yet finished. I therefore did a manual merge on my local copy of this repo first, creating a merge commit in order to bypass the pipelines for the 23.08 branch so that the extension can be built on and for Freedesktop runtime version 22.08.