### PR TITLE
Update Gradle to 8.6

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -166,7 +166,7 @@ modules:
           url-query: '["https://services.gradle.org/distributions/gradle-" + $version
             + "-bin.zip"][0]'
           versions:
-            - >=: 8
+            - >: 7
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -162,7 +162,7 @@ modules:
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases
-          version-query: map(select(.prerelease == false)) | first | .name
+          version-query: map(select(.prerelease == false)) | sort_by(.name) | last | .name
           url-query: '["https://services.gradle.org/distributions/gradle-" + $version
             + "-bin.zip"][0]'
           versions:

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -165,6 +165,8 @@ modules:
           version-query: map(select(.prerelease == false)) | first | .name
           url-query: '["https://services.gradle.org/distributions/gradle-" + $version
             + "-bin.zip"][0]'
+          versions:
+            - >=: 8
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -165,8 +165,6 @@ modules:
           version-query: map(select(.prerelease == false)) | sort_by(.name) | last | .name
           url-query: '["https://services.gradle.org/distributions/gradle-" + $version
             + "-bin.zip"][0]'
-          versions:
-            - >: 7
     build-commands:
       - unzip -q gradle-bin.zip -d $FLATPAK_DEST
       - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -156,9 +156,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-7.6.4-bin.zip
+        url: https://services.gradle.org/distributions/gradle-8.6-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 65c9bdb55d53349f3bc04d84b658589f6ab889e58280ecdc3714634c3f94aabf5354e7b52474008d2aa642eb42b3aa55cf569b11a8659c69341d2d1b9e97f1eb
+        sha512: 2429119280b2abf650f149d06d193893bb5a859fd2440355263ff143b43af232b3832253257d26c66f3f0abefb9d8e6af7074408e6eede577a6a387dddfdf402
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases


### PR DESCRIPTION
The external data checker must've 'updated' Gradle to 7.6.4 instead of 8.6. I also added a `versions` restriciton to the `gradle` module's `x-checker-data` so that it only checks for version of Gradle greater than or equal to 8, but I put in the version 8.6 URL and SHA512 value manually this time round.