### PR TITLE
[branch/23.08] Update bootstrap_jdk and java modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-21.0.5+11" date="2024-10-18">
+    <release version="jdk-21.0.6+7" date="2025-01-23">
       <description></description>
+    </release>
+    <release version="jdk-21.0.5+11" date="2024-10-18">
+      <description/>
     </release>
     <release version="jdk-21.0.4+7" date="2024-07-18">
       <description/>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -24,9 +24,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jdk_x64_linux_hotspot_21.0.5_11.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.6_7.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 0b5abec819b5c49a5e3feeb80ec97f508cb4436129b94a44195eacf24ff19077a6ed49381074a37f8c9f8fc71b9964f0ff035b62eb594290574c355f8231965a
+        sha512: fe1429daa45a8a48563ffd35fbef150fd28b3c5338f189785d6df511e34b04cba8e4fd573ce50e0fa8b5c07896ff1c4c60c18fe6b5d9f163d8af91ad50f2a07a
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -87,8 +87,8 @@ modules:
       - (cd $FLATPAK_DEST/jvm && ln -s openjdk-21.* openjdk-21)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.5+11.tar.gz
-        sha512: 567f66c9412939c30fda13670ab7d42ff8f10900f1238e207554fa6e93ca80e4963ebcf96c8533e724c21c41bcd10f83799cbaac13ea0a59c867b2de153fbf4f
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.6+7.tar.gz
+        sha512: 9b2b3ac9572bb1e523611dcb00db8a610721944f2cb715035a4f6ac2eff197488591a3af420b25cb4614cad80a4e7885b14919f54a32bb58864fcb3d9f37b3a8
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -37,9 +37,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.5_11.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.6_7.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 93a6d3c39c71bbec8a0b5d5501bbd9f2b44efcb7fb21a8c0e65fd15640f9b1b4b366be7298eb18eff3010ff41290f0a59544fee4efe16a8192cfe47394999485
+        sha512: 726936fad5d020cc41f55a9471171e46e4aa0d8f9418efea0832360850ce554bdaf5fec53e5f25f67f54db5d4b7e4fc603c70d8ffbde0ddbf39dc759bf807fb0
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=aarch64&image_type=jdk


### PR DESCRIPTION
bootstrap_jdk: Update java-openjdk.tar.bz2 to 21.0.6+7.0.LTS
java: Update jdk-21.0.5+11.tar.gz to jdk-21.0.6+7

(cherry picked from commits 9a78bc811c2046870ee6c8ae536a99845c6d6c27 and e9f28b87249f1c2cf12c0647da7815ec7b2c1066)
