### PR TITLE
[branch/23.08] Update bootstrap_jdk, java and maven modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-21.0.7+6" date="2025-04-17">
+    <release version="jdk-21.0.8+9" date="2025-07-18">
       <description></description>
+    </release>
+    <release version="jdk-21.0.7+6" date="2025-04-17">
+      <description/>
     </release>
     <release version="jdk-21.0.6+7" date="2025-01-23">
       <description/>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -24,9 +24,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 97295fb4db5ef86a143db50b8bc8fc5c95b8e7a3803c8e8bc8403be283fc00b132654e9305a32d17f2cc40112f6284b0931ce11763c853606c1f0b70674b9813
+        sha512: f5904c0ec0b927e35bc35d55bc67ad70cbb0b22566f367f2db519ad6867a8185e819cb0aea35c97741f7df2a10788a8f5aca10cd2c799423d0d561c915812556
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -37,9 +37,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.7_6.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.8_9.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: c4ace083c9a879a5192c20022a4fd61dcd7df6d4dff767f70b6c073f7d8cccbccb1f1cc63de7be60a228af53601f77d1d19a4073e70a377134fad393c6a30d41
+        sha512: 4bc38655b7e1fa639776449843af2d84cbaea9067635925e247ebd9dd958fb24cd2d6b59121ad86a2e65c293f46dc5ead0b0c0b916268e4618805c2e25aa5351
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -87,8 +87,8 @@ modules:
       - (cd $FLATPAK_DEST/jvm && ln -s openjdk-21.* openjdk-21)
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.7+6.tar.gz
-        sha512: e9fdb49da04d9434b455fc72bfe459fc1251a250673e65ab8d3c5ef2f8925839b7b87529db937c01afa8a814d86874c5b65dcc7382e5ca32c293c97282239ab5
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.8+9.tar.gz
+        sha512: e4f4694319903b4f64775dcccae02167315017b81fbbe1ea91b887fb101501118e69e2662ed5c6a913150e3838aa29d897326946bacf833a4888d974dba931d1
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -138,9 +138,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+        sha512: bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978
         x-checker-data:
           type: anitya
           project-id: 1894


### PR DESCRIPTION
bootstrap_jdk: Update java-openjdk.tar.bz2 to 21.0.8+9.0.LTS
java: Update jdk-21.0.7+6.tar.gz to jdk-21.0.8+9
maven: Update apache-maven-bin.tar.gz to 3.9.11

(cherry picked from commit de4963b0d558a234b01153464c7963bf2fd495ee)