### PR TITLE
[branch/24.08] Update bootstrap_jdk, java and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-21.0.8+9" date="2025-07-18">
+    <release version="jdk-21.0.9+10" date="2025-10-30">
       <description></description>
+    </release>
+    <release version="jdk-21.0.8+9" date="2025-07-18">
+      <description/>
     </release>
     <release version="jdk-21.0.7+6" date="2025-04-17">
       <description/>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -23,9 +23,9 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_x64_linux_hotspot_21.0.9_10.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: f5904c0ec0b927e35bc35d55bc67ad70cbb0b22566f367f2db519ad6867a8185e819cb0aea35c97741f7df2a10788a8f5aca10cd2c799423d0d561c915812556
+        sha512: 5209bc15c2c21372b32b8ed55f03aef91e400d151dcfdfab83d63569c12b13aeee7b9c1678c960797d47962396ca566ebed791f55fcef4f27a9450c0db0b4035
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -36,9 +36,9 @@ modules:
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.8_9.tar.gz
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.9%2B10/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.9_10.tar.gz
         dest-filename: java-openjdk.tar.bz2
-        sha512: 4bc38655b7e1fa639776449843af2d84cbaea9067635925e247ebd9dd958fb24cd2d6b59121ad86a2e65c293f46dc5ead0b0c0b916268e4618805c2e25aa5351
+        sha512: f0eec66822af2060c541ca7ebe6d3e0ad532a4937096df0a746d74ff2c4c94a4171fdfaee12b40f42a633f1bf87c9f353dfcbec91a3a34f17ded3c98bc1f3de8
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=aarch64&image_type=jdk
@@ -85,8 +85,8 @@ modules:
       - ln -sr $FLATPAK_DEST/jvm/openjdk-21/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.8+9.tar.gz
-        sha512: e4f4694319903b4f64775dcccae02167315017b81fbbe1ea91b887fb101501118e69e2662ed5c6a913150e3838aa29d897326946bacf833a4888d974dba931d1
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.9+10.tar.gz
+        sha512: 7f6447ca6f265da4c04a650bc6af1763f4c9e17021120df2e30ef2f159739a7aea822c8d504bda1bcd3016180deda30ad280dca7f66117e3cdcc82abcefb123f
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -155,9 +155,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-8.9-bin.zip
+        url: https://services.gradle.org/distributions/gradle-9.2.0-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 2b518f56b472ca505de7c4c315711bc7837a15cb343edd3e6479777a7d2a93e1a807f339c3b2f121c9be9e5d19bc39e793b322b2f536ed52c67587598eeb653e
+        sha512: 06c191dca9f3b4f8f38285755d86b0ab4665728f268b62421614394ccd9a0aa1377e95965bf5fb98f885a770bb60bb7465cdb3ba088780d999b27eb1598fa610
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -49,9 +49,11 @@ modules:
     build-commands:
       - mkdir -p $FLATPAK_DEST/bootstrap-java
       - tar xf java-openjdk.tar.bz2 --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
+
   - name: java
     buildsystem: autotools
     no-parallel-make: true
+    no-make-install: true
     config-opts:
       - --with-boot-jdk=/usr/lib/sdk/openjdk21/bootstrap-java
       - --with-jvm-variants=server
@@ -83,7 +85,9 @@ modules:
       - LOG=info
       - images
     post-install:
-      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-21.* openjdk-21)
+      - mkdir -p $FLATPAK_DEST/jvm $FLATPAK_DEST/bin
+      - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-21
+      - ln -sr $FLATPAK_DEST/jvm/openjdk-21/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
         url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.8+9.tar.gz
@@ -104,6 +108,7 @@ modules:
       - type: patch
         paths:
           - patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
+
   - name: cacerts
     buildsystem: simple
     sources:

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -51,40 +51,35 @@ modules:
       - tar xf java-openjdk.tar.bz2 --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
 
   - name: java
-    buildsystem: autotools
-    no-parallel-make: true
-    no-make-install: true
-    config-opts:
-      - --with-boot-jdk=/usr/lib/sdk/openjdk21/bootstrap-java
-      - --with-jvm-variants=server
-      - --with-version-build=2
-      - --with-version-pre=
-      - --with-version-opt=
-      - --with-vendor-version-string=21.9
-      - --with-vendor-name=Flathub
-      - --with-vendor-url=https://flathub.org
-      - --with-vendor-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21/issues
-      - --with-debug-level=release
-      - --with-native-debug-symbols=internal
-      - --enable-unlimited-crypto
-      - --with-zlib=system
-      - --with-libjpeg=system
-      - --with-giflib=system
-      - --with-libpng=system
-      - --with-lcms=system
-      - --with-harfbuzz=system
-      - --with-stdc++lib=dynamic
-      - --with-extra-cxxflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
-        -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
-      - --with-extra-cflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
-        -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
-      - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now -Wl,--as-needed
-      - --disable-javac-server
-      - --disable-warnings-as-errors
-    make-args:
-      - LOG=info
-      - images
-    post-install:
+    buildsystem: simple
+    build-commands:
+      - |
+        bash configure \
+           --with-boot-jdk=/usr/lib/sdk/openjdk21/bootstrap-java \
+           --with-jvm-variants=server \
+           --with-version-pre= \
+           --with-version-opt= \
+           --with-vendor-version-string=24.08 \
+           --with-vendor-name=Flathub \
+           --with-vendor-url=https://flathub.org \
+           --with-vendor-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21/issues \
+           --with-vendor-vm-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21/issues \
+           --with-debug-level=release \
+           --with-native-debug-symbols=internal \
+           --enable-unlimited-crypto \
+           --with-zlib=system \
+           --with-libjpeg=system \
+           --with-giflib=system \
+           --with-libpng=system \
+           --with-lcms=system \
+           --with-harfbuzz=system \
+           --with-stdc++lib=dynamic \
+           --with-extra-cflags="${CFLAGS}" \
+           --with-extra-cxxflags="${CXXFLAGS}" \
+           --with-extra-ldflags="${LDFLAGS}" \
+           --disable-javac-server \
+           --disable-warnings-as-errors
+      - make -j1 LOG=info images
       - mkdir -p $FLATPAK_DEST/jvm $FLATPAK_DEST/bin
       - cp -Lr build/linux-*-server-release/images/jdk $FLATPAK_DEST/jvm/openjdk-21
       - ln -sr $FLATPAK_DEST/jvm/openjdk-21/bin/* $FLATPAK_DEST/bin
@@ -101,13 +96,12 @@ modules:
           versions:
             - ==: 21
           is-main-source: true
-      - type: shell
-        commands:
-          - chmod a+x configure
-          - sed -i -e "s|@prefix@|$FLATPAK_DEST|" make/autoconf/spec.gmk.in
       - type: patch
         paths:
           - patches/0001-Allow-ccache-to-be-handled-by-GCC-wrappers.patch
+          - patches/0002-Remove-obsolete-throw-specifier-from-AnyObj-operator.patch
+          - patches/0003-FORBID_C_FUNCTION-needs-exception-spec-consistent-wi.patch
+          - patches/0004-Fix-missing-inline-includes-for-XList-and-ZList-dest.patch
 
   - name: cacerts
     buildsystem: simple

--- a/patches/0002-Remove-obsolete-throw-specifier-from-AnyObj-operator.patch
+++ b/patches/0002-Remove-obsolete-throw-specifier-from-AnyObj-operator.patch
@@ -1,0 +1,44 @@
+From 3a6bdbb7772f85e1bbb13067e48a11ad0ee4fc48 Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Fri, 31 Oct 2025 01:26:48 -0300
+Subject: [PATCH] Remove obsolete throw() specifier from AnyObj::operator new
+ definition
+
+Building with -fexceptions fails due to a mismatched exception specifier
+between the declaration and definition of AnyObj::operator new(size_t, Arena*):
+
+=== Output from failing command(s) repeated here ===
+* For target hotspot_variant-server_libjvm_objs_allocation.o:
+/run/build/java/src/hotspot/share/memory/allocation.cpp:114:7: error: declaration of 'static void* AnyObj::operator new(size_t, Arena*) throw ()' has a different exception specifier
+  114 | void* AnyObj::operator new(size_t size, Arena *arena) throw() {
+      |       ^~~~~~
+In file included from /run/build/java/src/hotspot/share/classfile/classLoaderData.hpp:28,
+                 from /run/build/java/src/hotspot/share/precompiled/precompiled.hpp:34:
+/run/build/java/src/hotspot/share/memory/allocation.hpp:504:9: note: from previous declaration 'static void* AnyObj::operator new(size_t, Arena*)'
+  504 |   void* operator new(size_t size, Arena *arena);
+      |         ^~~~~~~~
+
+* All command lines available in /run/build/java/build/linux-x86_64-server-release/make-support/failure-logs.
+=== End of repeated output ===
+
+This is a shorter backport of: https://github.com/openjdk/jdk21u-dev/commit/545ab3fdf6582c6237b173d158d229825f2b68c9
+---
+ src/hotspot/share/memory/allocation.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/hotspot/share/memory/allocation.cpp b/src/hotspot/share/memory/allocation.cpp
+index 64b00a136..120d0df53 100644
+--- a/src/hotspot/share/memory/allocation.cpp
++++ b/src/hotspot/share/memory/allocation.cpp
+@@ -111,7 +111,7 @@ void* ArenaObj::operator new(size_t size, Arena *arena) throw() {
+ // AnyObj
+ //
+ 
+-void* AnyObj::operator new(size_t size, Arena *arena) throw() {
++void* AnyObj::operator new(size_t size, Arena *arena) {
+   address res = (address)arena->Amalloc(size);
+   DEBUG_ONLY(set_allocation_type(res, ARENA);)
+   return res;
+-- 
+2.51.2
+

--- a/patches/0003-FORBID_C_FUNCTION-needs-exception-spec-consistent-wi.patch
+++ b/patches/0003-FORBID_C_FUNCTION-needs-exception-spec-consistent-wi.patch
@@ -1,0 +1,57 @@
+From 68cfb53cc8baeb79161ac6d7b0137d9a309aa0d0 Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Sat, 1 Nov 2025 17:24:42 -0300
+Subject: [PATCH] FORBID_C_FUNCTION needs exception spec consistent with
+ library declaration
+
+Fixes build failures when building with -fexceptions:
+
+=== Output from failing command(s) repeated here ===
+* For target hotspot_variant-server_libjvm_objs_mallocInfoDcmd.o:
+In file included from /run/build/java/src/hotspot/os/linux/mallocInfoDcmd.cpp:31:
+/usr/include/malloc.h:39:14: error: declaration of 'void* malloc(size_t) noexcept' has a different exception specifier
+   39 | extern void *malloc (size_t __size) __THROW __attribute_malloc__
+      |              ^~~~~~
+In file included from /run/build/java/src/hotspot/share/utilities/compilerWarnings.hpp:32,
+                 from /run/build/java/src/hotspot/share/utilities/debug.hpp:30,
+                 from /run/build/java/src/hotspot/share/memory/allocation.hpp:29,
+                 from /run/build/java/src/hotspot/share/classfile/classLoaderData.hpp:28,
+                 from /run/build/java/src/hotspot/share/precompiled/precompiled.hpp:34:
+/run/build/java/src/hotspot/share/utilities/globalDefinitions.hpp:205:25: note: from previous declaration 'void* malloc(size_t)'
+  205 | FORBID_C_FUNCTION(void* malloc(size_t size), "use os::malloc");
+      |                         ^~~~~~
+/run/build/java/src/hotspot/share/utilities/compilerWarnings_gcc.hpp:86:56: note: in definition of macro 'FORBID_C_FUNCTION'
+   86 |   extern "C" __attribute__((__warning__(alternative))) signature;
+      |                                                        ^~~~~~~~~
+   ... (rest of output omitted)
+
+* All command lines available in /run/build/java/build/linux-x86_64-server-release/make-support/failure-logs.
+=== End of repeated output ===
+
+This is a _very_ simplified backport of: https://github.com/openjdk/jdk/commit/4e59c63ec5a896a09f61a019e2fc5a2ec75ec40e
+---
+ src/hotspot/share/utilities/globalDefinitions.hpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/hotspot/share/utilities/globalDefinitions.hpp b/src/hotspot/share/utilities/globalDefinitions.hpp
+index 625fdcc41..d121ee3db 100644
+--- a/src/hotspot/share/utilities/globalDefinitions.hpp
++++ b/src/hotspot/share/utilities/globalDefinitions.hpp
+@@ -202,10 +202,10 @@ FORBID_C_FUNCTION(int vsnprintf(char*, size_t, const char*, va_list), "use os::v
+ 
+ // All of the following functions return raw C-heap pointers (sometimes as an option, e.g. realpath or getwd)
+ // or, in case of free(), take raw C-heap pointers. Don't use them unless you are really sure you must.
+-FORBID_C_FUNCTION(void* malloc(size_t size), "use os::malloc");
+-FORBID_C_FUNCTION(void* calloc(size_t nmemb, size_t size), "use os::malloc and zero out manually");
+-FORBID_C_FUNCTION(void free(void *ptr), "use os::free");
+-FORBID_C_FUNCTION(void* realloc(void *ptr, size_t size), "use os::realloc");
++FORBID_C_FUNCTION(void* malloc(size_t size) noexcept, "use os::malloc");
++FORBID_C_FUNCTION(void* calloc(size_t nmemb, size_t size) noexcept, "use os::malloc and zero out manually");
++FORBID_C_FUNCTION(void free(void *ptr) noexcept, "use os::free");
++FORBID_C_FUNCTION(void* realloc(void *ptr, size_t size) noexcept, "use os::realloc");
+ FORBID_C_FUNCTION(char* strdup(const char *s), "use os::strdup");
+ FORBID_C_FUNCTION(char* strndup(const char *s, size_t n), "don't use");
+ FORBID_C_FUNCTION(int posix_memalign(void **memptr, size_t alignment, size_t size), "don't use");
+-- 
+2.51.2
+

--- a/patches/0004-Fix-missing-inline-includes-for-XList-and-ZList-dest.patch
+++ b/patches/0004-Fix-missing-inline-includes-for-XList-and-ZList-dest.patch
@@ -1,0 +1,50 @@
+From ef55aaf4b4ac33e56ae12964de037c17a19df459 Mon Sep 17 00:00:00 2001
+From: guihkx <626206+guihkx@users.noreply.github.com>
+Date: Sat, 1 Nov 2025 17:24:28 -0300
+Subject: [PATCH] Fix missing inline includes for XList and ZList destructors
+
+This fixes linking when building OpenJDK with -fexceptions (one of the
+CFLAGS inherited from the Freedesktop SDK):
+
+=== Output from failing command(s) repeated here ===
+* For target hotspot_variant-server_libjvm_objs_BUILD_LIBJVM_link:
+/usr/lib/gcc/x86_64-unknown-linux-gnu/14.3.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /run/build/java/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/xPhysicalMemory.o: in function `XList<XMemory>::~XList()':
+make/hotspot/src/hotspot/share/gc/x/xList.hpp:54:(.text.unlikely+0x5): undefined reference to `XListNode<XMemory>::~XListNode()'
+/usr/lib/gcc/x86_64-unknown-linux-gnu/14.3.0/../../../../x86_64-unknown-linux-gnu/bin/ld: /run/build/java/build/linux-x86_64-server-release/hotspot/variant-server/libjvm/objs/zPhysicalMemory.o: in function `ZList<ZMemory>::~ZList()':
+make/hotspot/src/hotspot/share/gc/z/zList.hpp:54:(.text.unlikely+0x5): undefined reference to `ZListNode<ZMemory>::~ZListNode()'
+collect2: error: ld returned 1 exit status
+
+* All command lines available in /run/build/java/build/linux-x86_64-server-release/make-support/failure-logs.
+=== End of repeated output ===
+---
+ src/hotspot/share/gc/x/xPhysicalMemory.cpp | 1 +
+ src/hotspot/share/gc/z/zPhysicalMemory.cpp | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/hotspot/share/gc/x/xPhysicalMemory.cpp b/src/hotspot/share/gc/x/xPhysicalMemory.cpp
+index 20902cc05..908d7b6ff 100644
+--- a/src/hotspot/share/gc/x/xPhysicalMemory.cpp
++++ b/src/hotspot/share/gc/x/xPhysicalMemory.cpp
+@@ -27,6 +27,7 @@
+ #include "gc/x/xArray.inline.hpp"
+ #include "gc/x/xGlobals.hpp"
+ #include "gc/x/xLargePages.inline.hpp"
++#include "gc/x/xList.inline.hpp"
+ #include "gc/x/xNUMA.inline.hpp"
+ #include "gc/x/xPhysicalMemory.inline.hpp"
+ #include "logging/log.hpp"
+diff --git a/src/hotspot/share/gc/z/zPhysicalMemory.cpp b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+index 924bc7291..099adbfb9 100644
+--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
++++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+@@ -27,6 +27,7 @@
+ #include "gc/z/zArray.inline.hpp"
+ #include "gc/z/zGlobals.hpp"
+ #include "gc/z/zLargePages.inline.hpp"
++#include "gc/z/zList.inline.hpp"
+ #include "gc/z/zNMT.hpp"
+ #include "gc/z/zNUMA.inline.hpp"
+ #include "gc/z/zPhysicalMemory.inline.hpp"
+-- 
+2.51.2
+


### PR DESCRIPTION
bootstrap_jdk: Update java-openjdk.tar.bz2 to 21.0.9+10.0.LTS
java: Update jdk-21.0.8+9.tar.gz to jdk-21.0.9+10
gradle: Update gradle-bin.zip to 9.2.0

(cherry picked from commit c682fe30a8015140d0acd1e0029073ff4df61d4f)
(cherry picked from commit 021dda90b58a3aec5f9daac2cfb8d209f6851180)
(cherry picked from commit 3241e8d05eebc167292a3669fe7d03f96feeabf9)