### PR TITLE
[branch/24.08] Update java, ant, maven and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-21.0.10+7" date="2026-01-23">
+    <release version="jdk-21.0.11+10" date="2026-04-23">
       <description></description>
+    </release>
+    <release version="jdk-21.0.10+7" date="2026-01-23">
+      <description/>
     </release>
     <release version="jdk-21.0.9+10" date="2025-10-30">
       <description/>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -71,8 +71,8 @@ modules:
       - ln -sr $FLATPAK_DEST/jvm/openjdk-21/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.10+7.tar.gz
-        sha512: 3b74555e77bc0810a96b21f6e891d6d0b15fefefe8dc6ab317b5ba7dbf74f876b1cff430e307dee826fd53c85e99126cdbfa39ec295c9aa618d5ccd36368ef64
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.11+10.tar.gz
+        sha512: eae30515e060634366c303310402b7ca58bc7f93d4586e48f9538843b1e5d3f51411dc74a05fb3467397e5e5a037ebae3d9088e949bdb91ebe37813c2e3dec8b
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -102,9 +102,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.tar.gz
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.17-bin.tar.gz
         dest-filename: apache-ant-bin.tar.gz
-        sha512: d78427aff207592c024ff1552dc04f7b57065a195c42d398fcffe7a0145e8d00cd46786f5aa52e77ab0fdf81334f065eb8011eecd2b48f7228e97ff4cb20d16c
+        sha512: a96ca6455ec9af5e702df7d1ed5a2ec1cfb381eac3e9a767ecb6be1706e826941045e8fd7ca663ba101bc47bfa18351f540dd27e9e7af57908ac78e65268eee7
         x-checker-data:
           type: anitya
           project-id: 50
@@ -121,9 +121,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
+        sha512: 33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -140,9 +140,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+        url: https://services.gradle.org/distributions/gradle-9.4.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 6df0976acd118427d206c15716d24955e16ac80d362a6c9814764119e826580480b2d508b13e2740dfde81d13528fc46fe2c2c53b3d8b267093f09895a192a1c
+        sha512: 7aa7b84d6194c3d343c3c60a2c81d9f2aabf8c7ee0cc6b4330e9e4059a0b58762993feb9a5d95efe004aedfc0cf06c8faced4056bd2b8d47bdea4c34ce6f31f8
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases


### PR DESCRIPTION
java: Update jdk-21.0.10+7.tar.gz to jdk-21.0.11+10
ant: Update apache-ant-bin.tar.gz to 1.10.17
maven: Update apache-maven-bin.tar.gz to 3.9.15
gradle: Update gradle-bin.zip to 9.4.1

(cherry picked from commit 6874493d7c0d4238939933cb507865620f2f95ab)