### PR TITLE
[branch/24.08] Update java, maven and gradle modules

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -16,8 +16,11 @@
   <developer_name>Mat Booth</developer_name>
   <update_contact>mat.booth@gmail.com</update_contact>
   <releases>
-    <release version="jdk-21.0.11+10" date="2026-04-23">
+    <release version="jdk-21.0.12+8" date="2026-07-25">
       <description></description>
+    </release>
+    <release version="jdk-21.0.11+10" date="2026-04-23">
+      <description/>
     </release>
     <release version="jdk-21.0.10+7" date="2026-01-23">
       <description/>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -71,8 +71,8 @@ modules:
       - ln -sr $FLATPAK_DEST/jvm/openjdk-21/bin/* $FLATPAK_DEST/bin
     sources:
       - type: archive
-        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.11+10.tar.gz
-        sha512: eae30515e060634366c303310402b7ca58bc7f93d4586e48f9538843b1e5d3f51411dc74a05fb3467397e5e5a037ebae3d9088e949bdb91ebe37813c2e3dec8b
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.12+8.tar.gz
+        sha512: 59a88b7e3941d03b44baa5c4ed73e25b2060801b2e7a9eae0c4b7070775fe08a40198d96229feeab734a60a37281beee8524fbcff95d255f9e9d09ebb7e05be6
         x-checker-data:
           type: json
           url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
@@ -121,9 +121,9 @@ modules:
       - '*.cmd'
     sources:
       - type: file
-        url: http://archive.apache.org/dist/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
         dest-filename: apache-maven-bin.tar.gz
-        sha512: 33d81e0ec785f0207e3e5e3ffb61863e1dca5784c15ac3fb5ff105f69cffbea484eb8d473ea60467a63f7b0570eef8622f2fed8eee96acbe668aa313391cddb3
+        sha512: 831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6
         x-checker-data:
           type: anitya
           project-id: 1894
@@ -140,9 +140,9 @@ modules:
       - '*.bat'
     sources:
       - type: file
-        url: https://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+        url: https://services.gradle.org/distributions/gradle-9.6.1-bin.zip
         dest-filename: gradle-bin.zip
-        sha512: 7aa7b84d6194c3d343c3c60a2c81d9f2aabf8c7ee0cc6b4330e9e4059a0b58762993feb9a5d95efe004aedfc0cf06c8faced4056bd2b8d47bdea4c34ce6f31f8
+        sha512: 2a1efccc77114aa841b32ea5f79694d325c0220d4d57d26901f47d2ab41d38aec64f1a3b79a7629b6a925a1ba6c63e34a653f09ed216db2db6ccee28309b159c
         x-checker-data:
           type: json
           url: https://api.github.com/repos/gradle/gradle/releases


### PR DESCRIPTION
java: Update jdk-21.0.11+10.tar.gz to jdk-21.0.12+8
maven: Update apache-maven-bin.tar.gz to 3.9.16
gradle: Update gradle-bin.zip to 9.6.1

(cherry picked from commit 19cd046605da143b3732c096568ac4df57547f41)