### PR TITLE
Update runtime to 26.08 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,45 @@ For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/f
 
 You can bundle the JRE with your Flatpak application by adding this SDK extension to your Flatpak manifest and calling the install.sh script. For example:
 
-```
-{
-  "id" : "org.example.MyApp",
-  "runtime" : "org.freedesktop.Platform",
-  "runtime-version" : "25.08",
-  "sdk" : "org.freedesktop.Sdk",
-  "sdk-extensions" : [
-    "org.freedesktop.Sdk.Extension.openjdk21"
-  ],
-  "finish-args" : [
-    "--env=PATH=/app/jre/bin:/app/bin:/usr/bin"
-  ]
-  "modules" : [
-    {
-      "name" : "openjdk",
-      "buildsystem" : "simple",
-      "build-commands" : [
-        "/usr/lib/sdk/openjdk21/install.sh"
-      ]
-    },
-    {
-      "name" : "myapp",
-      "buildsystem" : "simple",
-      ....
-    }
-  ]
-  ....
-}
+```yaml
+app-id: com.example.myapp
+runtime: org.freedesktop.Platform
+runtime-version: '26.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk21
+command: myapp
+
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --env=PATH=/app/jre/bin:/app/bin:/usr/bin
+  - --env=JAVA_HOME=/app/jre
+  # ...
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk21/install.sh
+
+  - name: myapp
+    buildsystem: simple
+    build-options:
+      env:
+        PATH: /app/bin:/usr/bin:/usr/lib/sdk/openjdk21/bin
+        JAVA_HOME: /usr/lib/sdk/openjdk21/jvm/openjdk-21
+    build-commands:
+      - install -Dm755 -t /app/bin myapp
+      - install -Dm644 -t /app/share/com.example.myapp myapp.jar
+      # ...
+    sources:
+      - type: archive
+        url: https://example.com/myapp/download/myapp-1.0.0.tar.gz
+        # ...
+      - type: script
+        dest-filename: myapp
+        commands:
+          - exec java -jar /app/share/com.example.myapp/myapp.jar $@
+      # ...
 ```

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -1,7 +1,7 @@
 id: org.freedesktop.Sdk.Extension.openjdk21
-branch: '25.08'
+branch: '26.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '25.08'
+runtime-version: '26.08'
 build-extension: true
 sdk: org.freedesktop.Sdk
 separate-locales: false
@@ -45,7 +45,7 @@ modules:
            --with-jvm-variants=server \
            --with-version-pre= \
            --with-version-opt= \
-           --with-vendor-version-string=25.08 \
+           --with-vendor-version-string=26.08 \
            --with-vendor-name=Flathub \
            --with-vendor-url=https://flathub.org \
            --with-vendor-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21/issues \


### PR DESCRIPTION
Marking as draft because I want to build and test a least a couple of Java apps before creating the 26.08 branch.